### PR TITLE
Remove illegal characters from filename, updated README to specify correct pip package name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /tracks/
+*.bak

--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@ A simple python script that downloads OSRS music tracks from [the wiki](https://
 ## Usage
 Requires at least Python 3.7 as well as `pymediawiki`, `yt_dlp`, and `taglib`.
 
+To install dependencies:
+```
+pip install pymediawiki yt_dlp pytaglib
+```
+
 To run: `python3 osrsmusic.py` will autogenerate a "tracks" subfolder and fill it with ogg files. These will have the title, artist, and album details.
 
 ## Is this legal?

--- a/osrsmusic.py
+++ b/osrsmusic.py
@@ -14,6 +14,11 @@ print(f"Found {len(track_names)} tracks to download...")
 # download the tracks
 for track_name in track_names:
     track_name_formatted = track_name.replace("(music track)", "").strip() # removes disambiguation suffix
+    
+    # remove characters like ? from filenames which cause errors
+    illegal_chars = r"[<>:\"/\\|?*]"
+    track_name_formatted = re.sub(illegal_chars, "", track_name_formatted)
+    
     ydl_opts = {"playlist_items":"1", # this *should* download the latest version only
             "outtmpl": f"tracks/{track_name_formatted}.ogg"}
     with yt_dlp.YoutubeDL(ydl_opts) as ydl:


### PR DESCRIPTION
Small change after attempting to run in Windows and receiving exceptions for filenames that contained "?". Added an update with example `pip` command since taglib is installed under pytaglib.